### PR TITLE
PacketPlayClientKeepAlive 1.12+ support added

### DIFF
--- a/src/main/java/cc/ghast/packet/wrapper/packet/play/client/PacketPlayClientKeepAlive.java
+++ b/src/main/java/cc/ghast/packet/wrapper/packet/play/client/PacketPlayClientKeepAlive.java
@@ -15,10 +15,14 @@ public class PacketPlayClientKeepAlive extends Packet<ClientPacket> implements R
         super("PacketPlayInKeepAlive", player, version);
     }
 
-    private int id;
+    private long id;
 
     @Override
     public void read(ProtocolByteBuf byteBuf) {
-        this.id = byteBuf.readVarInt();
+        if (version.isBelow(ProtocolVersion.V1_12)) {
+            this.id = byteBuf.readVarInt();
+        } else {
+            this.id = byteBuf.readLong();
+        }
     }
 }


### PR DESCRIPTION
PacketPlayInKeepAlive now works on 1.7.10 - 1.16.4